### PR TITLE
Update dev-getting-started URL

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -17,7 +17,7 @@ Airship is a global open source community independently governed at the OpenStac
 
 ## Contribute
 
-- **Developer Guide:** [https://airshipit.readthedocs.io/en/latest/dev-getting-started.html](https://airshipit.readthedocs.io/en/latest/dev-getting-started.html)
+- **Developer Guide:** [https://airship-docs.readthedocs.io/en/latest/dev-getting-started.html](https://airship-docs.readthedocs.io/en/latest/dev-getting-started.html)
 
 ---
 

--- a/site/index.md
+++ b/site/index.md
@@ -6,7 +6,7 @@ hero:
   headline: Elevate Your Infrastructure
   button:
     title: Get Started
-    url: https://airshipit.readthedocs.io/en/latest/dev-getting-started.html
+    url: https://airship-docs.readthedocs.io/en/latest/dev-getting-started.html
     
 getInvolvedSteps:
   - title: Join us on the mailing list


### PR DESCRIPTION
Update dev-getting-started URL. Airship-in-a-bottle repository is being deprecated,
and airshipit.readthedocs.org would no longer be used. There is a deprecation warning
on it's pages already published.