### PR TITLE
Disables md link tracking.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,13 +57,6 @@ module.exports = {
               destinationDir: 'static',
             },
           },
-          {
-            resolve: "gatsby-remark-google-analytics-track-links",
-            options: {
-              target: "_blank",
-              rel: "noopener noreferrer",
-            }
-          },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "gatsby-plugin-sass": "^2.2.0",
     "gatsby-plugin-sharp": "^2.5.1",
     "gatsby-remark-copy-linked-files": "^2.2.0",
-    "gatsby-remark-google-analytics-track-links": "^0.0.5",
     "gatsby-remark-images": "^3.2.0",
     "gatsby-remark-images-medium-zoom": "^1.4.0",
     "gatsby-remark-relative-images": "^0.2.1",


### PR DESCRIPTION
Temporary disables markdown link tracking until link generation is [fixed](https://github.com/jamessimone/gatsby-remark-google-analytics-track-links/pull/4).

Addresses #83