### PR TITLE
Fixes site’s link url in repo’s readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  Airship website
 
-This is the public repo to mantain the  Airship website at [airshipit.org](airshipit.org).
+This is the public repo to mantain the  Airship website at [airshipit.org](https://airshipit.org).
 
 ## Overview
 


### PR DESCRIPTION
Now correctly links to [airshipit.org](https://airshipit.org) site.