### PR TITLE
Enables md link tracking.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,6 +57,13 @@ module.exports = {
               destinationDir: 'static',
             },
           },
+          {
+            resolve: "gatsby-remark-google-analytics-track-links",
+            options: {
+              target: "_blank",
+              rel: "noopener noreferrer",
+            }
+          },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-sass": "^2.2.0",
     "gatsby-plugin-sharp": "^2.5.1",
     "gatsby-remark-copy-linked-files": "^2.2.0",
+    "gatsby-remark-google-analytics-track-links": "^0.0.6",
     "gatsby-remark-images": "^3.2.0",
     "gatsby-remark-images-medium-zoom": "^1.4.0",
     "gatsby-remark-relative-images": "^0.2.1",


### PR DESCRIPTION
Anchor generation for markdown links has been [fixed](https://github.com/jamessimone/gatsby-remark-google-analytics-track-links/pull/4) in latest plugin version.