### PR TITLE
Removing unused params from CMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -233,7 +233,6 @@ collections:
             ]}         
           - {label: "Title", name: title, widget: string}
           - {label: "Sub Title", name: subTitle, widget: string}
-          - {label: "Blog URL", name: blogUrl, widget: string}          
           - {label: "Body", name: body, widget: markdown}
       - file: "src/pages/supporters/index.md"
         label: "Supporters"


### PR DESCRIPTION
Removes the blogUrl parameter from the community page in the CMS