### PR TITLE
Update Airship documentation links

### DIFF
--- a/src/content/footer-nav.json
+++ b/src/content/footer-nav.json
@@ -47,7 +47,7 @@
         },
         {
           "text": "Documentation",
-          "link": "https://airship-treasuremap.readthedocs.io/en/latest/"
+          "link": "https://docs.airshipit.org/"
         }
       ]
     }

--- a/src/pages/blog/2019-airship-election.md
+++ b/src/pages/blog/2019-airship-election.md
@@ -51,4 +51,4 @@ information about how Airship can manage infrastructure deployments and
 lifecycle. There’s a wealth of information about how to get started by using
 [Airship in a Bottle](https://opendev.org/airship/airship-in-a-bottle),
 attending one of the [weekly meetings](https://wiki.openstack.org/wiki/Airship#Get_in_Touch), and [getting
-involved with development](https://airshipit.readthedocs.io/en/latest/dev-getting-started.html).
+involved with development](https://docs.airshipit.org/develop/developers.html).

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -146,7 +146,7 @@ You can join the new Slack channel [*here*](https://airshipit.org/slack).
 The Airship community is committed to confirming, resolving, and disclosing all reported security vulnerabilities.
 
 The Airship community recently added the following
-[*documentation*](https://airshipit.readthedocs.io/projects/airship-docs/en/latest/security/guide.html) for more
+[*documentation*](https://docs.airshipit.org/learn/vulnerabilities.html) for more
 information on how detected vulnerabilities are confirmed, resolved, and disclosed. This new documentation describes how
 a user can report security vulnerabilities in Airship software.
 

--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -18,7 +18,7 @@ Airship is a global open source community independently governed at the OpenStac
 ## Try Airship
 
 - **Airship Whitepaper:** [https://airshipit.org/collateral/Airship_2.0_White_Paper.pdf](https://airshipit.org/collateral/Airship_2.0_White_Paper.pdf) - an overview of the design approach that Airship 2.0 is using to declaratively manage open infrastructure
-- **Airship Treasuremap:** [https://airship-treasuremap.readthedocs.io/en/latest](https://airship-treasuremap.readthedocs.io/en/latest/)
+- **Airship Treasuremap:** [https://docs.airshipit.org/treasuremap/](https://docs.airshipit.org/treasuremap/)
 - **Airship Git Repository:** [https://opendev.org/airship/treasuremap](https://opendev.org/airship/treasuremap)
 - **Airship in a Bottle:** [https://opendev.org/airship/treasuremap/src/branch/master/tools/deployment/aiab](https://opendev.org/airship/treasuremap/src/branch/master/tools/deployment/aiab)
 
@@ -26,7 +26,7 @@ Airship is a global open source community independently governed at the OpenStac
 
 ## Contribute
 
-- **Developer Guide:** [https://airship-docs.readthedocs.io/en/latest/dev-getting-started.html](https://airship-docs.readthedocs.io/en/latest/dev-getting-started.html)
+- **Developer Guide:** [https://docs.airshipit.org/develop/developers.html](https://docs.airshipit.org/develop/developers.html)
 
 ---
 

--- a/src/pages/software/index.md
+++ b/src/pages/software/index.md
@@ -26,7 +26,7 @@ intro:
       image: /img/document.svg
       link: 
         text: Go to Treasuremap
-        url: https://airship-treasuremap.readthedocs.io/en/latest/
+        url: https://docs.airshipit.org/treasuremap/
 ---
 
 <br/>


### PR DESCRIPTION
Migration to docs.airshipit.org recently completed. This change updates
the documentation links to point to our new documentation.

Signed-off-by: Drew Walters <andrew.walters@att.com>