### PR TITLE
Archival of pre-alpha blogs

### DIFF
--- a/src/pages/blog/airship-update-april-2020.md
+++ b/src/pages/blog/airship-update-april-2020.md
@@ -16,7 +16,7 @@ Committee.<!-- more -->
 - Learn how to set up a Cluster API development environment in this
 [*tutorial*](https://deploy-preview-87--airshipit.netlify.app/blog/cluster-api-development-environment/), for more
 information on how Cluster API will be used in Airship 2.0, see this [*blog post*](
-https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html).
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html).
 
 <br>
 
@@ -27,18 +27,25 @@ The Airship blog is a great way to keep up with what's going on in the community
 posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
 component. The first six Airship 2.0 Blog posts are already available:
 
-- [*Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
-- [*Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-- [*Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-- [*Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-   https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-- [*Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-- [*Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-april-2020.md
+++ b/src/pages/blog/airship-update-april-2020.md
@@ -32,7 +32,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-april-2020.md
+++ b/src/pages/blog/airship-update-april-2020.md
@@ -31,8 +31,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-april-2020.md
+++ b/src/pages/blog/airship-update-april-2020.md
@@ -16,7 +16,7 @@ Committee.<!-- more -->
 - Learn how to set up a Cluster API development environment in this
 [*tutorial*](https://deploy-preview-87--airshipit.netlify.app/blog/cluster-api-development-environment/), for more
 information on how Cluster API will be used in Airship 2.0, see this [*blog post*](
-https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html).
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/).
 
 <br>
 
@@ -31,21 +31,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-april-2020.md
+++ b/src/pages/blog/airship-update-april-2020.md
@@ -31,7 +31,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-february-2020.md
+++ b/src/pages/blog/airship-update-february-2020.md
@@ -18,7 +18,7 @@ What follows is the Airship Community Update for the month of February 2020, bro
     - [Ian Pittwood](https://opendev.org/airship/election/raw/branch/master/candidates/2020/WC/pittwoodian@gmail.com)
     (Accenture) to the Working Committee.
 - Airship's year in review was featured in the OpenStack Foundation Annual Report. For more information
-  see this [blog post](https://www.airshipit.org/blog/a-year-in-review-getting-confirmed-and-looking-ahead-to-2-0.html).
+  see this [blog post](https://www.airshipit.org/blog/a-year-in-review-getting-confirmed-and-looking-ahead-to-2-0/).
 
 <br>
 
@@ -33,21 +33,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-february-2020.md
+++ b/src/pages/blog/airship-update-february-2020.md
@@ -33,7 +33,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-february-2020.md
+++ b/src/pages/blog/airship-update-february-2020.md
@@ -29,18 +29,25 @@ The Airship blog is a great way to keep up with what's going on in the community
 posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
 component. The first six Airship 2.0 Blog posts are already available:
 
-- [*Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
-- [*Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-- [*Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-   https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-- [*Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-- [*Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-- [*Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-february-2020.md
+++ b/src/pages/blog/airship-update-february-2020.md
@@ -33,8 +33,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-february-2020.md
+++ b/src/pages/blog/airship-update-february-2020.md
@@ -34,7 +34,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-july-2020.md
+++ b/src/pages/blog/airship-update-july-2020.md
@@ -31,7 +31,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-july-2020.md
+++ b/src/pages/blog/airship-update-july-2020.md
@@ -30,21 +30,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-july-2020.md
+++ b/src/pages/blog/airship-update-july-2020.md
@@ -30,8 +30,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-july-2020.md
+++ b/src/pages/blog/airship-update-july-2020.md
@@ -30,7 +30,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-july-2020.md
+++ b/src/pages/blog/airship-update-july-2020.md
@@ -26,18 +26,25 @@ introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, a
 The first six Airship 2.0 Blog posts are already available, and illustrate the design thoughts on the road to the alpha
 milestone:
 
-* [_Airship Blog Series 1 - Evolution Towards 2.0_](
-  https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
-* [_Airship Blog Series 2 - An Educated Evolution_](
-  https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-* [_Airship Blog Series 3 - Airship 2.0 Architecture High Level_](
-  https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-* [_Airship Blog Series 4 - Shipyard - an Evolution of the Front Door_](
-  https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-* [_Airship Blog Series 5 - Drydock and Its Relationship to Cluster API_](
-  https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-* [_Airship Blog Series 6 - Armada Growing Pains_](
-  https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-june-2020.md
+++ b/src/pages/blog/airship-update-june-2020.md
@@ -23,7 +23,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-june-2020.md
+++ b/src/pages/blog/airship-update-june-2020.md
@@ -18,12 +18,25 @@ posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new featu
 component. The first six Airship 2.0 Blog posts are already available, and illustrate the design thoughts on the road to
 the alpha milestone:
 
-* [_Airship Blog Series 1 - Evolution Towards 2.0_](https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
-* [_Airship Blog Series 2 - An Educated Evolution_](https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-* [_Airship Blog Series 3 - Airship 2.0 Architecture High Level_](https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-* [_Airship Blog Series 4 - Shipyard - an Evolution of the Front Door_](https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-* [_Airship Blog Series 5 - Drydock and Its Relationship to Cluster API_](https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-* [_Airship Blog Series 6 - Armada Growing Pains_](https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 
@@ -44,7 +57,8 @@ entire week.
 
 Conversations with StarlingX included an update on Airship 2.0 and laid out the deprecation cycle for Armada. We are
 encouraging the StarlingX community to check out the Flux Helm Operator which will be replacing Armada in Airship 2.0.
-For more details on Armada's evolution from Airship 1.0 to Airship 2.0 see this [_blog post_](https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html).
+For more details on Armada's evolution from Airship 1.0 to Airship 2.0 see this [_blog post_](
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html).
 
 There was Airship representation at the Edge Working group, to provide an update on Airship 2.0 and how it targets
 various edge computing use cases.

--- a/src/pages/blog/airship-update-june-2020.md
+++ b/src/pages/blog/airship-update-june-2020.md
@@ -22,8 +22,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-june-2020.md
+++ b/src/pages/blog/airship-update-june-2020.md
@@ -22,7 +22,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-june-2020.md
+++ b/src/pages/blog/airship-update-june-2020.md
@@ -22,21 +22,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 
@@ -58,7 +58,7 @@ entire week.
 Conversations with StarlingX included an update on Airship 2.0 and laid out the deprecation cycle for Armada. We are
 encouraging the StarlingX community to check out the Flux Helm Operator which will be replacing Armada in Airship 2.0.
 For more details on Armada's evolution from Airship 1.0 to Airship 2.0 see this [_blog post_](
-https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html).
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/).
 
 There was Airship representation at the Edge Working group, to provide an update on Airship 2.0 and how it targets
 various edge computing use cases.

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -31,7 +31,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -30,21 +30,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 
@@ -112,7 +112,7 @@ By aligning with the CNCF direction
 
 For more details, check out the Airship 2.0 preview video [*here*](https://www.youtube.com/watch?v=13v3z4EIK9I).
 
-In the [*February Update*](https://www.airshipit.org/blog/airship-update-february-2020.html), we mentioned that Airship
+In the [*February Update*](https://www.airshipit.org/blog/airship-update-february-2020/), we mentioned that Airship
 2.0 progress is tracked in [*Github Issues*](https://github.com/airshipit/airshipctl/issues).
 
 The progress shown below is for [*airshipctl*](https://opendev.org/airship/airshipctl), the new Airship 2.0 client.

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -30,8 +30,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -30,7 +30,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-march-2020.md
+++ b/src/pages/blog/airship-update-march-2020.md
@@ -26,18 +26,25 @@ The Airship blog is a great way to keep up with what's going on in the community
 posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
 component. The first six Airship 2.0 Blog posts are already available:
 
-- [*Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
-- [*Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-- [*Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-- [*Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-   https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-- [*Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-- [*Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-may-2020.md
+++ b/src/pages/blog/airship-update-may-2020.md
@@ -38,17 +38,17 @@ Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review t
 before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-may-2020.md
+++ b/src/pages/blog/airship-update-may-2020.md
@@ -34,8 +34,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-may-2020.md
+++ b/src/pages/blog/airship-update-may-2020.md
@@ -30,18 +30,25 @@ The Airship blog is a great way to keep up with what's going on in the community
 posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
 component. The first six Airship 2.0 Blog posts are already available:
 
-- [*Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains.html)
-- [*Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
-- [*Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
-- [*Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-   https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
-- [*Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-- [*Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-may-2020.md
+++ b/src/pages/blog/airship-update-may-2020.md
@@ -35,7 +35,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-may-2020.md
+++ b/src/pages/blog/airship-update-may-2020.md
@@ -34,7 +34,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-november-2019.md
+++ b/src/pages/blog/airship-update-november-2019.md
@@ -36,7 +36,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-november-2019.md
+++ b/src/pages/blog/airship-update-november-2019.md
@@ -35,8 +35,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-november-2019.md
+++ b/src/pages/blog/airship-update-november-2019.md
@@ -24,6 +24,35 @@ What follows is the Airship Community Update for the month of November, 2019, br
 
 <br>
 
+## **AIRSHIP BLOG**
+
+The Airship blog is a great way to keep up with what's going on in the community. The Airship community publishes
+[*blog posts*](https://www.airshipit.org/blog/) regularly, including the recent Airship 2.0 Blog series. These blog
+posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
+component. The first six Airship 2.0 Blog posts are already available:
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+
+<br>
+
 ## **AIRSHIP TECHNICAL GATHERING AT KUBECON**
 
 More than 20 developers from Airship community gathered in KubeCon and discussed various technical topics, including:

--- a/src/pages/blog/airship-update-november-2019.md
+++ b/src/pages/blog/airship-update-november-2019.md
@@ -35,21 +35,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-november-2019.md
+++ b/src/pages/blog/airship-update-november-2019.md
@@ -35,7 +35,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-october-2019.md
+++ b/src/pages/blog/airship-update-october-2019.md
@@ -44,8 +44,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship-update-october-2019.md
+++ b/src/pages/blog/airship-update-october-2019.md
@@ -45,7 +45,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-october-2019.md
+++ b/src/pages/blog/airship-update-october-2019.md
@@ -44,21 +44,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-october-2019.md
+++ b/src/pages/blog/airship-update-october-2019.md
@@ -44,7 +44,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-october-2019.md
+++ b/src/pages/blog/airship-update-october-2019.md
@@ -33,13 +33,32 @@ What follows is the Airship Community Update for the month of October, 2019, bro
 
 ![](/img/growth-of-community-201910.png)
 
-## **THE AIRSHIP BLOG**
+## **AIRSHIP BLOG**
 
-The Airship blog is a great way to keep up with what's going on in the community. The Airship community publishes [blog posts](https://www.airshipit.org/blog/) regularly, including the recent:
+The Airship blog is a great way to keep up with what's going on in the community. The Airship community publishes
+[*blog posts*](https://www.airshipit.org/blog/) regularly, including the recent Airship 2.0 Blog series. These blog
+posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
+component. The first six Airship 2.0 Blog posts are already available:
 
-- [Airship 2.0 Blog Series 4 "Shipyard - an Evolution of the Front Door"](https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html): Shipyard provides a frontend API within Airship environments that allows users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what Shipyard looks like today and how it interacts with other Airship components. Read more: [https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html](https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html).
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
-- [Airship 2.0 Blog Series #5 "Drydock and Its Relationship to Cluster API"](https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html): As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure. Read more: [https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html](https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html).
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-september-2019.md
+++ b/src/pages/blog/airship-update-september-2019.md
@@ -37,7 +37,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](

--- a/src/pages/blog/airship-update-september-2019.md
+++ b/src/pages/blog/airship-update-september-2019.md
@@ -37,21 +37,21 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)
 - [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution/)
 - [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level/)
 - [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 - [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
-  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/)
 - [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
-   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 <br>
 

--- a/src/pages/blog/airship-update-september-2019.md
+++ b/src/pages/blog/airship-update-september-2019.md
@@ -38,7 +38,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)

--- a/src/pages/blog/airship-update-september-2019.md
+++ b/src/pages/blog/airship-update-september-2019.md
@@ -26,13 +26,32 @@ Welcome to the Airship Community Update, a digest of the latest developments and
 
 <br>
 
-## **THE AIRSHIP BLOG**
+## **AIRSHIP BLOG**
 
-The Airship blog is a great way to keep up with what's going on in the community. The Airship community publishes [*blog posts*](https://www.airshipit.org/blog/) regularly, including the recent Airship 2.0 Blog series. These blogs introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each component. The first three Airship 2.0 Blog posts are already available:
+The Airship blog is a great way to keep up with what's going on in the community. The Airship community publishes
+[*blog posts*](https://www.airshipit.org/blog/) regularly, including the recent Airship 2.0 Blog series. These blog
+posts introduce the changes from Airship 1.0 to Airship 2.0, highlight new features, and detail the evolution of each
+component. The first six Airship 2.0 Blog posts are already available:
 
-- [*Airship Blog Series 1 - Evolution Towards 2.0*](https://www.airshipit.org/blog/airship-blog-series-1-evolution-towards-2.0.html)
-- [*Airship Blog Series 2 - An Educated Evolution*](https://www.airshipit.org/blog/airship-blog-series-2-an-educated-evolution.html)
-- [*Airship Blog Series 3 - Airship 2.0 Architecture High Level*](https://www.airshipit.org/blog/airship-blog-series-3-airship-2.0-architecture-high-level.html)
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
+- [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.html)
+- [*Pre-Alpha Airship Blog Series 2 - An Educated Evolution*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.html)
+- [*Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.html)
+- [*Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.html)
+- [*Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API*](
+  https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.html)
+- [*Pre-Alpha Airship Blog Series 6 - Armada Growing Pains*](
+   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.html)
 
 <br>
 

--- a/src/pages/blog/airship-update-september-2019.md
+++ b/src/pages/blog/airship-update-september-2019.md
@@ -37,8 +37,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 - [*Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0*](
   https://www.airshipit.org/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0/)

--- a/src/pages/blog/airship2-is-alpha.md
+++ b/src/pages/blog/airship2-is-alpha.md
@@ -29,7 +29,7 @@ and approaches we made in some of the previous blog posts. We believe it’s wor
 
 <br>
 
-[_**Shipyard - an Evolution of the Front Door**_](https://www.airshipit.org/blog/airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
+[_**Shipyard - an Evolution of the Front Door**_](https://www.airshipit.org/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door/)
 
 In this blog post, we mentioned that the _airshipctl_ utility operates on a Kubernetes cluster security context.
 The _**airshipctl**_ utility is the main entry point for bootstrapping a cluster, collecting and pushing
@@ -42,7 +42,7 @@ simplify lifecycle management in a future post.
 
 <br>
 
-[_**Armada - growing pains**_](https://www.airshipit.org/blog/airship-blog-series-6-armada-growing-pains/)
+[_**Armada - growing pains**_](https://www.airshipit.org/blog/pre-alpha-airship-blog-series-6-armada-growing-pains/)
 
 In this blog post, we discussed the expected evolution for Armada, the path led us to the need to embrace
 Kubernetes CRDs, integrate with Helm v3, and take advantage of a CNCF workflow engine like Argo. We also touched
@@ -139,9 +139,9 @@ upgrade, destroy) of Kubernetes-conformant clusters using a declarative API:
 
 The Cluster API relies on provider implementations for different environments. As mentioned in [Blog Post #5, Drydock
 and its Relationship to Cluster API](
-https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/), the Airship
-community collaborates with the Cluster API Metal3 Baremetal provider (CAPM3) community to realize a production quality,
-resilient, secure and mature Baremetal provisioner.
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/), the
+Airship community collaborates with the Cluster API Metal3 Baremetal provider (CAPM3) community to realize a production
+quality, resilient, secure and mature Baremetal provisioner.
 
 As mentioned above, the Kubeadm project itself has matured in terms of cluster provisioning, and it’s integrated with
 the Cluster API via the Cluster API Bootstrap Provider and the Cluster API Control Plane Provider. Cluster API Bootstrap

--- a/src/pages/blog/cluster-api-development-environment.md
+++ b/src/pages/blog/cluster-api-development-environment.md
@@ -25,10 +25,10 @@ Kubernetes-style APIs to cluster creation, configuration, and management. It pro
 on top of core Kubernetes to manage the lifecycle of a Kubernetes cluster.
 
 In a previous [blog post](
-https://www.airshipit.org/blog/airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/), Alan Meadows and
-Rodolfo Pacheco discussed the evolution of Airship 1.0 to Airship 2.0 and the relationship between [Drydock](
-https://opendev.org/airship/drydock) and [Cluster API](https://cluster-api.sigs.k8s.io/). It's an interesting read,
-looking at how Cluster API will be used by Airship 2.0.
+https://www.airshipit.org/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api/), Alan
+Meadows and Rodolfo Pacheco discussed the evolution of Airship 1.0 to Airship 2.0 and the relationship between
+[Drydock](https://opendev.org/airship/drydock) and [Cluster API](https://cluster-api.sigs.k8s.io/). It's an interesting
+read, looking at how Cluster API will be used by Airship 2.0.
 
 Today I will provide you the documentation and my tested step-by-step directions to creating a Cluster API development
 environment using Kind. This development environment will allow you to deploy virtual nodes as Docker containers in

--- a/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 [Airship](https://www.airshipit.org/) allows cloud operators to manage the entire lifecycle of sites, including their creation, minor updates, configuration changes, and major uplifts such as OpenStack upgrades. Airship accomplishes this using a unified, declarative, fully containerized, cloud native platform.<!-- more -->

--- a/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 [Airship](https://www.airshipit.org/) allows cloud operators to manage the entire lifecycle of sites, including their creation, minor updates, configuration changes, and major uplifts such as OpenStack upgrades. Airship accomplishes this using a unified, declarative, fully containerized, cloud native platform.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 [Airship](https://www.airshipit.org/) allows cloud operators to manage the entire lifecycle of sites, including their creation, minor updates, configuration changes, and major uplifts such as OpenStack upgrades. Airship accomplishes this using a unified, declarative, fully containerized, cloud native platform.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 [Airship](https://www.airshipit.org/) allows cloud operators to manage the entire lifecycle of sites, including their creation, minor updates, configuration changes, and major uplifts such as OpenStack upgrades. Airship accomplishes this using a unified, declarative, fully containerized, cloud native platform.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-1-evolution-towards-2.0.md
@@ -1,12 +1,19 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 1 - Evolution Towards 2.0
+title: Pre-Alpha Airship Blog Series 1 - Evolution Towards 2.0
 author: Ryan van Wyk, Rodolfo Pacheco and Alan Meadows
 date: 2019-06-12T09:00:00.000Z
 category: 
   - label: Airship 2.0
     id: category-C98iZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
 [Airship](https://www.airshipit.org/) allows cloud operators to manage the entire lifecycle of sites, including their creation, minor updates, configuration changes, and major uplifts such as OpenStack upgrades. Airship accomplishes this using a unified, declarative, fully containerized, cloud native platform.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
@@ -1,12 +1,19 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 2 - An Educated Evolution
+title: Pre-Alpha Airship Blog Series 2 - An Educated Evolution
 author: Rodolfo Pacheco and Alan Meadows
 date: 2019-07-11T09:00:00.000Z
 category: 
   - label: Airship 2.0
     id: category-C98iZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
 Airship 1.0 dramatically improved the way we provision and manage the infrastructure. Navigating through the journey towards Airship 1.0 release, we have learned many lessons.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 Airship 1.0 dramatically improved the way we provision and manage the infrastructure. Navigating through the journey towards Airship 1.0 release, we have learned many lessons.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 Airship 1.0 dramatically improved the way we provision and manage the infrastructure. Navigating through the journey towards Airship 1.0 release, we have learned many lessons.<!-- more -->

--- a/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 Airship 1.0 dramatically improved the way we provision and manage the infrastructure. Navigating through the journey towards Airship 1.0 release, we have learned many lessons.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-2-an-educated-evolution.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 Airship 1.0 dramatically improved the way we provision and manage the infrastructure. Navigating through the journey towards Airship 1.0 release, we have learned many lessons.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
@@ -1,12 +1,19 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 3 - Airship 2.0 Architecture High Level
+title: Pre-Alpha Airship Blog Series 3 - Airship 2.0 Architecture High Level
 author: Alan Meadows and Rodolfo Pacheco
 date: 2019-08-10T09:00:00.000Z
 category: 
   - label: Airship 2.0
     id: category-C98iZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
 In order to achieve the goals of vanishing complexity, as well as broaden the variety of supported use cases for Airship 2.0, we shifted far more of the process to the left. We will accomplish this by introducing [*airshipctl*](https://opendev.org/airship/airshipctl). The [*airshipctl*](https://opendev.org/airship/airshipctl) command line interface is really the heart of the Airship 2.0 platform. It places an emphasis on a thick client that is effectively able to speak to k8s in remote sites and natively understands [*Argo*](https://argoproj.github.io/) workflows to drive cluster life cycle management. This contrasts with Airship 1.0 which leveraged a Shipyard API in the remote site, which was a long-lived service and used many Airship specific projects instantiated in the site to accomplish the life cycle management of Airship documents, kubernetes, baremetal nodes, and helm charts.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 In order to achieve the goals of vanishing complexity, as well as broaden the variety of supported use cases for Airship 2.0, we shifted far more of the process to the left. We will accomplish this by introducing [*airshipctl*](https://opendev.org/airship/airshipctl). The [*airshipctl*](https://opendev.org/airship/airshipctl) command line interface is really the heart of the Airship 2.0 platform. It places an emphasis on a thick client that is effectively able to speak to k8s in remote sites and natively understands [*Argo*](https://argoproj.github.io/) workflows to drive cluster life cycle management. This contrasts with Airship 1.0 which leveraged a Shipyard API in the remote site, which was a long-lived service and used many Airship specific projects instantiated in the site to accomplish the life cycle management of Airship documents, kubernetes, baremetal nodes, and helm charts.<!-- more -->

--- a/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 In order to achieve the goals of vanishing complexity, as well as broaden the variety of supported use cases for Airship 2.0, we shifted far more of the process to the left. We will accomplish this by introducing [*airshipctl*](https://opendev.org/airship/airshipctl). The [*airshipctl*](https://opendev.org/airship/airshipctl) command line interface is really the heart of the Airship 2.0 platform. It places an emphasis on a thick client that is effectively able to speak to k8s in remote sites and natively understands [*Argo*](https://argoproj.github.io/) workflows to drive cluster life cycle management. This contrasts with Airship 1.0 which leveraged a Shipyard API in the remote site, which was a long-lived service and used many Airship specific projects instantiated in the site to accomplish the life cycle management of Airship documents, kubernetes, baremetal nodes, and helm charts.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 In order to achieve the goals of vanishing complexity, as well as broaden the variety of supported use cases for Airship 2.0, we shifted far more of the process to the left. We will accomplish this by introducing [*airshipctl*](https://opendev.org/airship/airshipctl). The [*airshipctl*](https://opendev.org/airship/airshipctl) command line interface is really the heart of the Airship 2.0 platform. It places an emphasis on a thick client that is effectively able to speak to k8s in remote sites and natively understands [*Argo*](https://argoproj.github.io/) workflows to drive cluster life cycle management. This contrasts with Airship 1.0 which leveraged a Shipyard API in the remote site, which was a long-lived service and used many Airship specific projects instantiated in the site to accomplish the life cycle management of Airship documents, kubernetes, baremetal nodes, and helm charts.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-3-airship-2.0-architecture-high-level.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 In order to achieve the goals of vanishing complexity, as well as broaden the variety of supported use cases for Airship 2.0, we shifted far more of the process to the left. We will accomplish this by introducing [*airshipctl*](https://opendev.org/airship/airshipctl). The [*airshipctl*](https://opendev.org/airship/airshipctl) command line interface is really the heart of the Airship 2.0 platform. It places an emphasis on a thick client that is effectively able to speak to k8s in remote sites and natively understands [*Argo*](https://argoproj.github.io/) workflows to drive cluster life cycle management. This contrasts with Airship 1.0 which leveraged a Shipyard API in the remote site, which was a long-lived service and used many Airship specific projects instantiated in the site to accomplish the life cycle management of Airship documents, kubernetes, baremetal nodes, and helm charts.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 *Shipyard* provides a frontend API within Airship environments that allow users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what *Shipyard* looks like today and how it interacts with other Airship components:<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 *Shipyard* provides a frontend API within Airship environments that allow users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what *Shipyard* looks like today and how it interacts with other Airship components:<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 *Shipyard* provides a frontend API within Airship environments that allow users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what *Shipyard* looks like today and how it interacts with other Airship components:<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 *Shipyard* provides a frontend API within Airship environments that allow users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what *Shipyard* looks like today and how it interacts with other Airship components:<!-- more -->

--- a/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-4-shipyard-an-evolution-of-the-front-door.md
@@ -1,12 +1,19 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 4 - Shipyard - an Evolution of the Front Door
+title: Pre-Alpha Airship Blog Series 4 - Shipyard - an Evolution of the Front Door
 author: Alan Meadows and Rodolfo Pacheco
 date: 2019-09-10T09:00:00.000Z
 category: 
   - label: Airship 2.0
     id: category-C98iZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
 *Shipyard* provides a frontend API within Airship environments that allow users to push their declared documents into sites and execute pre-defined Directed Acyclic Graphs (DAGs) against those declarations. DAG is a directed graph data structure for topological ordering. From an architectural perspective, this is what *Shipyard* looks like today and how it interacts with other Airship components:<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure.<!-- more -->

--- a/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
@@ -1,12 +1,19 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 5 - Drydock and Its Relationship to Cluster API
+title: Pre-Alpha Airship Blog Series 5 - Drydock and Its Relationship to Cluster API
 author: Alan Meadows and Rodolfo Pacheco
 date: 2019-10-22T09:00:00.000Z
 category: 
   - label: Airship 2.0
     id: category-C98iZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
 
 As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-5-drydock-and-its-relationship-to-cluster-api.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 As part of the evolution of Airship 1.0, an enduring goal has remained supporting multiple provisioning backends beyond just bare metal. This includes those that can provision to third-party clouds and to other use cases like OpenStack VMs as well as enable you to bring your own infrastructure.<!-- more -->
 

--- a/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
@@ -1,12 +1,20 @@
 ---
 templateKey: blog-post
-title: Airship Blog Series 6 - Armada Growing Pains
+title: Pre-Alpha Airship Blog Series 6 - Armada Growing Pains
 author: Alan Meadows and Rodolfo Pacheco
 date: 2020-01-30T15:25:05.000Z
 category: 
   - label: News & Announcements
     id: category-A7fnZYrE1
 ---
+
+_**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. Upon completing the first major
+milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
+design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
+using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
+before the Airship 2.0 beta milestone._
+
 Helm, the Kubernetes package manager, defined a mechanism to define and deploy a set of Kubernetes artifacts and their
 dependencies as a chart. The Helm CLI tool really targeted operators wishing to install a single helm chart at a time
 using the command line.  What was missing for users like Airship was the ability to declaratively define several helm

--- a/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
@@ -13,7 +13,7 @@ milestone, Alpha, the community took some time to reflect on lessons learned and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
 Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 beta milestone._
+before the Airship 2.0 Alpha milestone._
 
 Helm, the Kubernetes package manager, defined a mechanism to define and deploy a set of Kubernetes artifacts and their
 dependencies as a chart. The Helm CLI tool really targeted operators wishing to install a single helm chart at a time

--- a/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
@@ -12,7 +12,7 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviewing these changes before reading blogs
 marked as "Pre-Alpha."_
 
 Helm, the Kubernetes package manager, defined a mechanism to define and deploy a set of Kubernetes artifacts and their

--- a/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
-as "Pre-Alpha."_
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). We recommend reviews these changes before reading blogs
+marked as "Pre-Alpha."_
 
 Helm, the Kubernetes package manager, defined a mechanism to define and deploy a set of Kubernetes artifacts and their
 dependencies as a chart. The Helm CLI tool really targeted operators wishing to install a single helm chart at a time

--- a/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
+++ b/src/pages/blog/pre-alpha-airship-blog-series-6-armada-growing-pains.md
@@ -12,8 +12,8 @@ _**UPDATE 03-August-2020:** Airship 2.0 development spans multiple milestones. U
 milestone, Alpha, the community took some time to reflect on lessons learned and how they impacted the direction and
 design of Airship 2.0. We have summarized these lessons learned and how the design has changed over time - including
 using different technologies and approaches. You can read more about these changes here: [Airship 2.0 is Alpha - Lessons
-Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs posted
-before the Airship 2.0 Alpha milestone._
+Learned](https://www.airshipit.org/blog/airship2-is-alpha/). You should review these changes before reading blogs marked
+as "Pre-Alpha."_
 
 Helm, the Kubernetes package manager, defined a mechanism to define and deploy a set of Kubernetes artifacts and their
 dependencies as a chart. The Helm CLI tool really targeted operators wishing to install a single helm chart at a time


### PR DESCRIPTION
This change:
- Adds a disclaimer to all pages containing links to the `pre-alpha`
  blog series, those blogs that were posted prior to reaching Alpha
  status. This disclaimer notifies the reader of design decision
  changes, and that the summary post `airship2-is-alpha` should be
  read prior to reading any other blogs to reconcile inaccurate
  information.
- Updates the filenames (and URLs) to the pre-alpha blog series to
  clearly differentiate these pre-alpha blogs from other upcoming
  post-alpha blogs
- Updates the titles of the pre-alpha blogs with a "Pre-Alpha"
  prefix
- Standardizes the Airship blog series section of each TC newsletter

Signed-off-by: Alexander Hughes <Alexander.Hughes@pm.me>